### PR TITLE
Add include paths from findcasacore/rest

### DIFF
--- a/AppAgent/AppUtils/CMakeLists.txt
+++ b/AppAgent/AppUtils/CMakeLists.txt
@@ -20,7 +20,7 @@ set(appUtils_src
     )
 add_library(apputils ${appUtils_src})
 install(TARGETS apputils DESTINATION ${LIBRARY_INSTALL_DIR})
-target_link_libraries(apputils casa_ms)
+target_link_libraries(apputils ${CASACORE_LIBRARIES})
 MEQPACKAGE_ADD_LIBRARIES(apputils)
 
 add_executable(addbitflagcol src/addbitflagcol.cc)

--- a/AppAgent/AppUtils/src/wsrt_j2convert.cc
+++ b/AppAgent/AppUtils/src/wsrt_j2convert.cc
@@ -62,7 +62,7 @@
 #else
 	#if CASACORE_MINOR_VERSION >= 4
 		#include <casacore/casa/IO/ArrayIO.h>
-	#elif
+	#else
 		#include <casacore/casa/Arrays/ArrayIO.h>
 	#endif
 #endif

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,7 @@ if(CASACORE_FOUND)
     add_definitions(-DHAVE_AIPSPP)
     message("-- Casacore include directories found in ${CASACORE_INCLUDE_DIR}")
     message("-- Casacore libraries found in ${CASACORE_LIBRARIES}")
+    include_directories(${CASACORE_INCLUDE_DIR})
 endif(CASACORE_FOUND)
 
 find_package(Casarest REQUIRED COMPONENTS synthesis)
@@ -117,6 +118,7 @@ find_package(Casarest REQUIRED COMPONENTS synthesis)
 if(CASAREST_FOUND)
     message("-- Casarest include directories found in ${CASAREST_INCLUDE_DIR}")
     message("-- Casarest libraries found in ${CASAREST_LIBRARIES}")
+    include_directories(${CASAREST_INCLUDE_DIR})
 endif(CASAREST_FOUND)
 
 # -- compiler defaults


### PR DESCRIPTION
This fixes a problem with outdated include paths when
compiling on a system with both custom and system casacore/rest packages